### PR TITLE
fix: point typings to the right place

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React hook for the Streams API",
   "main": "./dist/index.js",
   "module": "./dist/es/index.js",
-  "typings": "./dist/index.d.ts",
+  "typings": "./typings/index.d.ts",
   "files": [
     "dist/**/*",
     "src/*",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Got this error trying to use in a ts project:

```
Could not find a declaration file for module 'react-fetch-streams'. '/Users/mmkal/src/storybot/node_modules/react-fetch-streams/dist/index.js' implicitly has an 'any' type.
```

**Does this PR introduce a breaking change?**

No

**Other information**
